### PR TITLE
✨ api_fetcher(api_fetcher.ts): ajouter une méthode pour retourner une…

### DIFF
--- a/src/api_fetcher/api_fetcher.ts
+++ b/src/api_fetcher/api_fetcher.ts
@@ -1,5 +1,6 @@
 import { Request } from "express";
 import { ApiFetcherInterface } from "./api_fetcher.interface";
+import ApiDefaultResponse from "../api_parser/api_constantes";
 
 export default class ApiFetcher implements ApiFetcherInterface {
     _request: Request;
@@ -10,10 +11,10 @@ export default class ApiFetcher implements ApiFetcherInterface {
         this._request = _request;
         this.initHeader(_request, _mstarget);
     }
-    async fetch(): Promise<Object> {
+    async fetch(): Promise<Map<any, any>> {
         const response = await fetch(`${this.getTarget()}`, this.getFetchOptions())
         const _ms_response = await response.json();
-        return _ms_response ?? {};
+        return _ms_response ?? ApiDefaultResponse.toJSON("ERROR");
     }
 
     setHeaderKey(headerKey: string, headerValue: string) {

--- a/src/api_parser/api_constantes.ts
+++ b/src/api_parser/api_constantes.ts
@@ -40,4 +40,7 @@ export default abstract class ApiDefaultResponse implements ApiInterface {
         const get = ApiResponseMap.map.get(key) ?? error;
         return get as ApiInterface;
     }
+    static toMap(defaultResponse: string): Map<string, Object> {
+        return JSON.parse(JSON.stringify(ApiDefaultResponse.get(defaultResponse)));
+    }
 }


### PR DESCRIPTION
… réponse par défaut

♻️ api_parser(api_constantes.ts): refactoriser la méthode pour retourner une réponse par défaut sous forme de Map La classe ApiFetcher a été mise à jour pour retourner une réponse par défaut à partir de la classe ApiDefaultResponse si la réponse de l'API est nulle. Cela améliore la gestion des erreurs et la cohérence des réponses par défaut. La méthode toMap de la classe ApiDefaultResponse a été refactorisée pour retourner la réponse par défaut sous forme de Map, ce qui rend la structure de données plus claire et facilite la manipulation des réponses par défaut.